### PR TITLE
Hugo/fix error pg migrations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,9 +12,9 @@
 !docker/mysql/alexandrie.toml
 !docker/mysql/Cargo.toml
 !docker/mysql/mysql-compose.yaml
-!docker/postgresql/alexandrie.toml
-!docker/postgresql/Cargo.toml
-!docker/postgresql/postgresql-compose.yaml
+!docker/postgres/alexandrie.toml
+!docker/postgres/Cargo.toml
+!docker/postgres/postgres-compose.yaml
 !docker/startup.sh
 !migrations
 !alexandrie

--- a/docker/postgres/postgres-compose.yaml
+++ b/docker/postgres/postgres-compose.yaml
@@ -2,7 +2,7 @@
 # This is an expansion upon the docker-compose.yaml file in the root of this repo
 # It applies additional configuration to use a postgres database
 #
-# Apply it like `docker-compose -f docker-compose.yaml -f docker/postgresql/postgres-compose.yaml up`
+# Apply it like `docker-compose -f docker-compose.yaml -f docker/postgres/postgres-compose.yaml up`
 # (Note file options should be applied before the `up` command)
 #
 version: "3.7"
@@ -37,4 +37,4 @@ services:
 secrets:
   postgres_root_pass:
     # this path is relative to the repo's root docker-compose file
-    file: ./docker/postgresql/rootpass.txt
+    file: ./docker/postgres/rootpass.txt

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -64,7 +64,7 @@ if [ "${DATABASE}" = "mysql" ] || [ "${DATABASE}" = "postgres" ]; then
         export DATABASE_URL=$(grep "^url" alexandrie.toml | awk '{print substr($3,2,length($3)-2)}')
         if [ "${DATABASE}" = "mysql" ]; then
             export MIGRATION_DIRECTORY=migrations/mysql
-        elif [ "${DATABASE}" = "postgresql" ]; then
+        elif [ "${DATABASE}" = "postgres" ]; then
             export MIGRATION_DIRECTORY=migrations/postgres
         fi
 

--- a/docs/src/whats-available/docker.md
+++ b/docs/src/whats-available/docker.md
@@ -24,7 +24,7 @@ A small bit of setup is required before you can start the docker containers. Fir
 * Set `GIT_SSH_KEY` to a new or existing passwordless SSH key. The `.pub` key associated with this key should be added to github/gitlab/etc. to grant access to clone and push the crate index.
 
 
-By default Alexandrie will use SQLite. If you want to use either MySQL or PostgreSQL instead, you'll need to create a file at either `docker/mysqsl/rootpass.txt` or `docker/postgresql/rootpass.txt` which contains the password that will be given to the root user of the database.
+By default Alexandrie will use SQLite. If you want to use either MySQL or PostgreSQL instead, you'll need to create a file at either `docker/mysql/rootpass.txt` or `docker/postgres/rootpass.txt` which contains the password that will be given to the root user of the database.
 
 
 ### Additional Configuration


### PR DESCRIPTION
While performing the migrations for PostgreSQL, the following error occurs:

```
Failed with: Invalid migration directory, the directory's name should be <timestamp>_<name_of_migration>, and it should only contain up.sql and down.sql
```

It seems to come from the following [line](https://github.com/Hirevo/alexandrie/blob/master/docker/startup.sh#L67):

```
elif [ "${DATABASE}" = "postgresql" ]; then
```

which should be:

```
elif [ "${DATABASE}" = "postgres" ]; then
```

I also noticed some kind of confusion between the existing repository `docker/postgres` and `docker/postgresql` that doesn't exist. In the [documentation](https://github.com/Hirevo/alexandrie/blob/master/docs/src/whats-available/docker.md#user-configuration), the `docker/postgresql/rootpass.txt` path is mentioned but IMHO, it should be `docker/postgres/rootpass.txt`.

Same remark for these lines:
- https://github.com/Hirevo/alexandrie/blob/master/docker/postgres/postgres-compose.yaml#L5
- https://github.com/Hirevo/alexandrie/blob/master/docker/postgres/postgres-compose.yaml#L40

The goal of this MR is to:
- remove the error while performing the PostgreSQL migration
- bring some consistency by removing all the notions to `docker/postgresql`